### PR TITLE
Fix group search

### DIFF
--- a/WorkSpaceOneImporter.py
+++ b/WorkSpaceOneImporter.py
@@ -193,7 +193,7 @@ class WorkSpaceOneImporter(Processor):
 
         # get OG ID from GROUPID
         try:
-            r = requests.get(BASEURL + '/api/system/groups/search?name=' + GROUPID, headers=headers)
+            r = requests.get(BASEURL + '/api/system/groups/search?groupid=' + GROUPID, headers=headers)
             result = r.json()
         except AttributeError:
             raise ProcessorError(


### PR DESCRIPTION
Change initial OG search to use groupid, as specified in the recipe plist, instead of name.